### PR TITLE
changes to build the package in introduction rmd

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -92,8 +92,8 @@ print(tail(gene_entrez))
 ```{r sample filtering}
 # Get indices of samples that are primary tumor and adjacent normal
 idcs_tumor_normal <- obj$filterSampleType(colnames(exp_count_mat), c("11", "01"))
-idcs_tumor <- idcs_tumor_normal$index[idcs_tumor_normal$type == "01"]
-idcs_normal <- idcs_tumor_normal$index[idcs_tumor_normal$type == "11"]
+idcs_tumor <- idcs_tumor_normal$index[idcs_tumor_normal$sample_type == "01"]
+idcs_normal <- idcs_tumor_normal$index[idcs_tumor_normal$sample_type == "11"]
 # Get indices of samples passing purity filtering
 idcs_purity_tumor <- obj$filterPurity(colnames(exp_count_mat[,idcs_tumor]))
 # Get indices of nonduplicates
@@ -148,27 +148,30 @@ Here, we will show how to aggregate methylation values to get gene-level informa
 
 ```{r methylation operations}
 ## Load methylation data
-load('~/Projects/TCGA_data/LUAD/luad_methylation_betas.Rdata')
-## transform column names to original UUIDs and mapt to TCGA barcodes
-rownames(betas) <- betas$probeID
-colnames(betas)[-1] <- colnames(betas)[-1] %>%
-  str_replace("X","") %>%
-  str_replace_all("\\.","-")
-betas_uuided <- betas
-colnames(betas)[-1] <- obj$mapUUIDtoTCGA(colnames(betas)[-1])[,2]
+## This dataset needs to be available in the specified path in order to build the project
+## I am commenting this out because it is not available in the package
 
-## Remove duplicates from beta value matrix (for simplicity, remove duplicates 'at random')
-betas <- betas[,!duplicated(colnames(betas))]
+# load('~/Projects/TCGA_data/LUAD/luad_methylation_betas.Rdata')
+# ## transform column names to original UUIDs and mapt to TCGA barcodes
+# rownames(betas) <- betas$probeID
+# colnames(betas)[-1] <- colnames(betas)[-1] %>%
+#   str_replace("X","") %>%
+#   str_replace_all("\\.","-")
+# betas_uuided <- betas
+# colnames(betas)[-1] <- obj$mapUUIDtoTCGA(colnames(betas)[-1])[,2]
 
-## Map probes to promoter regions (500 bp upstream to TSS)
-probemap <- obj$mapProbesToGenes(probelist = betas$probeID,
-                                 rangeUp = 500,
-                                 rangeDown = 0)
-gene_prom_meth <- obj$probeToMeanPromoterMethylation(methylation_betas = betas,
-                                                     genesOfInterest = gene_names[intersect(idcs_prot, idcs_genes_mintpm)],
-                                                     probe_gene_map = probemap)
+# ## Remove duplicates from beta value matrix (for simplicity, remove duplicates 'at random')
+# betas <- betas[,!duplicated(colnames(betas))]
 
-print(gene_prom_meth[1:5,1:5])
+# ## Map probes to promoter regions (500 bp upstream to TSS)
+# probemap <- obj$mapProbesToGenes(probelist = betas$probeID,
+#                                  rangeUp = 500,
+#                                  rangeDown = 0)
+# gene_prom_meth <- obj$probeToMeanPromoterMethylation(methylation_betas = betas,
+#                                                      genesOfInterest = gene_names[intersect(idcs_prot, idcs_genes_mintpm)],
+#                                                      probe_gene_map = probemap)
+
+# print(gene_prom_meth[1:5,1:5])
 
 ```
 
@@ -178,13 +181,13 @@ print(gene_prom_meth[1:5,1:5])
 Here we will show additional features such as methylation-based cell proportion estimates and smoking indicator.
 
 ```{r meth features}
-## Get smoking status of individuals through AHRR methylation marker
-smoking_ind <- obj$extractAHRRMethylation(betas)
-print(head(smoking_ind))
+# ## Get smoking status of individuals through AHRR methylation marker
+# smoking_ind <- obj$extractAHRRMethylation(betas)
+# print(head(smoking_ind))
 
-## Estimate cell proportions from methylation values through EpiSCORE
-episcores <- obj$estimateCellCountsEpiSCORE(methylation_betas = betas_uuided, tissue = 'Lung')
-print(head(episcores))
+# ## Estimate cell proportions from methylation values through EpiSCORE
+# episcores <- obj$estimateCellCountsEpiSCORE(methylation_betas = betas_uuided, tissue = 'Lung')
+# print(head(episcores))
 ```
 
 


### PR DESCRIPTION
I tried to run the steps recommended in order to put the code on CRAN.
1. `R CMD build NetSciDataCompanion`
2.  `R CMD check --as-cran NetSciDataCompanion_0.0.0.9000.tar.gz`

This PR fixes an issue with the introduction.Rmd file , such that 1 isnow running. I still get two errors for 2. I am pasting the log here, as CRAN recommends that ALL ERRORS need to be solved in order to be even considered for CRAN.

```
* using log directory ‘/Users/violafanfani/Documents/uni-harvard/repos/NetSciDataCompanion.Rcheck’
* using R version 4.3.2 (2023-10-31)
* using platform: aarch64-apple-darwin20 (64-bit)
* R was compiled by
    Apple clang version 14.0.0 (clang-1400.0.29.202)
    GNU Fortran (GCC) 12.2.0
* running under: macOS Ventura 13.6.4
* using session charset: UTF-8
* using option ‘--as-cran’
* checking for file ‘NetSciDataCompanion/DESCRIPTION’ ... OK
* this is package ‘NetSciDataCompanion’ version ‘0.0.0.9000’
* package encoding: UTF-8
* checking CRAN incoming feasibility ... WARNING
Maintainer: ‘First Last <first.last@example.com>’

New submission

Version contains large components (0.0.0.9000)

Non-FOSS package license (`use_mit_license()`)

Unknown, possibly misspelled, fields in DESCRIPTION:
  ‘Remotes’

Strong dependencies not in mainstream repositories:
  EpiSCORE, presto, TCGAPurityFiltering

DESCRIPTION fields with placeholder content:
  Description: what the package does (one paragraph).

Found the following URLs which should use \doi (with the DOI name only):
  File ‘estimateCellCountsEpiSCORE.Rd’:
    https://doi.org/10.1186/s13059-020-02126-9
* checking package namespace information ... OK
* checking package dependencies ... NOTE
Depends: includes the non-default packages:
  'data.table', 'dplyr', 'edgeR', 'EpiSCORE', 'GenomicDataCommons',
  'huge', 'magrittr', 'presto', 'recount', 'recount3', 'stringr',
  'TCGAPurityFiltering', 'TCGAutils', 'tidyr'
Adding so many packages to the search path is excessive and importing
selectively is preferable.
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking serialization versions ... OK
* checking whether package ‘NetSciDataCompanion’ can be installed ... [21s/21s] WARNING
Found the following significant warnings:
  Warning: package ‘GenomeInfoDb’ was built under R version 4.3.3
See ‘/Users/violafanfani/Documents/uni-harvard/repos/NetSciDataCompanion.Rcheck/00install.out’ for details.
* checking installed package size ... NOTE
  installed size is 13.6Mb
  sub-directories of 1Mb or more:
    extdata  13.2Mb
* checking package directory ... OK
* checking for future file timestamps ... OK
* checking ‘build’ directory ... OK
* checking DESCRIPTION meta-information ... WARNING
Non-standard license specification:
  `use_mit_license()`
Standardizable: FALSE
Authors@R field gives persons with invalid ORCID identifiers:
  First Last <first.last@example.com> [aut, cre] (YOUR-ORCID-ID)
* checking top-level files ... NOTE
Non-standard files/directories found at top level:
  ‘20230725NetSciDataCompanion_0.0.0.9000.pdf’ ‘demo.Rmd’ ‘demo.html’
  ‘example.R’ ‘my_testsuite.R’
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking use of S3 registration ... OK
* checking dependencies in R code ... NOTE
Packages in Depends field not imported from:
  ‘EpiSCORE’ ‘GenomicDataCommons’ ‘TCGAPurityFiltering’ ‘TCGAutils’
  ‘data.table’ ‘dplyr’ ‘edgeR’ ‘huge’ ‘magrittr’ ‘presto’ ‘recount’
  ‘recount3’ ‘stringr’ ‘tidyr’
  These packages need to be imported from (in the NAMESPACE file)
  for when this namespace is loaded but not attached.
package 'methods' is used but not declared
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... [17s/17s] NOTE
CreateNetSciDataCompanionObject: no visible global function definition
  for ‘CreateTCGAPurityFilteringObject’
CreateNetSciDataCompanionObject: no visible global function definition
  for ‘read.table’
CreateNetSciDataCompanionObject: no visible global function definition
  for ‘read.csv’
NetSciDataCompanion: no visible global function definition for ‘new’
Undefined global functions or variables:
  CreateTCGAPurityFilteringObject new read.csv read.table
Consider adding
  importFrom("methods", "new")
  importFrom("utils", "read.csv", "read.table")
to your NAMESPACE file (and ensure that your DESCRIPTION Imports field
contains 'methods').

Found if() conditions comparing class() to string:
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(bc1) != "character" | class(bc2) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(expression_rds_obj) != "RangedSummarizedExperiment") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(UUIDs) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(TCGA_barcodes) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(TCGA_barcodes) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(types_of_samples) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(TCGA_barcodes) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(TCGA_barcodes) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(TCGA_barcodes) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(rds_gene_info) != "data.frame") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(norm_threshold) != "numeric" | norm_threshold <= 0) ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(sample_fraction) != "numeric" | sample_fraction <= 0 | sample_fraction >= 1) ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(rds_gene_info) != "data.frame") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(chroms) != "character") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(rds_gene_info) != "data.frame") ...
File ‘NetSciDataCompanion/R/NetSciDataCompanion.R’: if (class(gene_names) != "character") ...
Use inherits() (or maybe is()) instead.
* checking Rd files ... WARNING
prepare_Rd: extractSampleAndGeneInfo.Rd:7-9: Dropping empty section \description
prepare_Rd: extractSampleAndGeneInfo.Rd:17-19: Dropping empty section \details
prepare_Rd: extractSampleAndGeneInfo.Rd:35-37: Dropping empty section \note
prepare_Rd: extractSampleAndGeneInfo.Rd:29-31: Dropping empty section \references
prepare_Rd: extractSampleAndGeneInfo.Rd:41-43: Dropping empty section \seealso
prepare_Rd: extractSampleAndGeneInfo.Rd:44-45: Dropping empty section \examples
checkRd: (5) extractSampleAndGeneInfo.Rd:0-46: Must have a \description
prepare_Rd: filterGenesProteins.Rd:16-19: Dropping empty section \details
prepare_Rd: filterGenesProteins.Rd:27-28: Dropping empty section \references
prepare_Rd: logCPMNormalization.Rd:16-19: Dropping empty section \details
prepare_Rd: mapBarcodeToBarcode.Rd:23-26: Dropping empty section \details
prepare_Rd: mapBarcodeToBarcode.Rd:33-35: Dropping empty section \references
prepare_Rd: mapProbesToGenes.Rd:6-7: Dropping empty section \description
prepare_Rd: mapProbesToGenes.Rd:18-20: Dropping empty section \details
prepare_Rd: mapProbesToGenes.Rd:32-34: Dropping empty section \note
prepare_Rd: mapProbesToGenes.Rd:38-40: Dropping empty section \seealso
prepare_Rd: mapProbesToGenes.Rd:41: Dropping empty section \examples
checkRd: (5) mapProbesToGenes.Rd:0-42: Must have a \description
prepare_Rd: probeToMeanPromoterMethylation.Rd:17-19: Dropping empty section \references
* checking Rd metadata ... OK
* checking Rd line widths ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... WARNING
Functions or methods with usage in documentation object 'convertBetaToM' but not in code:
  ‘convertBetaToM’

Functions or methods with usage in documentation object 'estimateCellCountsEpiSCORE' but not in code:
  ‘estimateCellCountsEpiSCORE’

Functions or methods with usage in documentation object 'extractSampleAndGeneInfo' but not in code:
  ‘extractSampleAndGeneInfo’

Functions or methods with usage in documentation object 'filterBarcodesIntersection' but not in code:
  ‘filterBarcodesIntersection’

Functions or methods with usage in documentation object 'filterChromosome' but not in code:
  ‘filterTumorType’

Functions or methods with usage in documentation object 'filterDuplicatesSeqDepth' but not in code:
  ‘filterDuplicatesSeqDepth’

Functions or methods with usage in documentation object 'filterDuplicatesSeqDepthOther' but not in code:
  ‘filterDuplicatesSeqDepthOther’

Functions or methods with usage in documentation object 'filterGenesByTPM' but not in code:
  ‘filterGenesByTPM’

Functions or methods with usage in documentation object 'filterGenesProteins' but not in code:
  ‘filterGenesProteins’

Functions or methods with usage in documentation object 'filterPurity' but not in code:
  ‘filterPurity’

Functions or methods with usage in documentation object 'filterSampleType' but not in code:
  ‘filterSampleType’

Functions or methods with usage in documentation object 'filterTumorType' but not in code:
  ‘filterTumorType’

Functions or methods with usage in documentation object 'geneNameToENSG' but not in code:
  ‘geneNameToENSG’

Functions or methods with usage in documentation object 'getGeneInfo' but not in code:
  ‘getGeneInfo’

Functions or methods with usage in documentation object 'logCPMNormalization' but not in code:
  ‘logCPMNormalization’

Functions or methods with usage in documentation object 'logTPMNormalization' but not in code:
  ‘logTPMNormalization’

Functions or methods with usage in documentation object 'mapBarcodeToBarcode' but not in code:
  ‘mapBarcodeToBarcode’

Functions or methods with usage in documentation object 'mapProbesToGenes' but not in code:
  ‘mapProbesToGenes’

Functions or methods with usage in documentation object 'probeToMeanPromoterMethylation' but not in code:
  ‘probeToMeanPromoterMethylation’

* checking Rd \usage sections ... WARNING
Objects in \usage without \alias in documentation object 'filterChromosome':
  ‘filterTumorType’

Functions with \usage entries need to have the appropriate \alias
entries, and all their arguments documented.
The \usage entries must correspond to syntactically valid R code.
See chapter ‘Writing R documentation files’ in the ‘Writing R
Extensions’ manual.
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking installed files from ‘inst/doc’ ... OK
* checking files in ‘vignettes’ ... OK
* checking examples ... NONE
* checking for unstated dependencies in ‘tests’ ... WARNING
'library' or 'require' call not declared from: ‘testthat’
* checking tests ...
 [31s/42s] ERROR
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
  ══ Failed ══════════════════════════════════════════════════════════════════════
  ── 1. Failure ('test_mapBarcodeToBarcode.R:19:3'): mapBarcodeToBarcode function 
  my_friend$mapBarcodeToBarcode(bc1, bc2)$idcs1 not equal to c(NA).
  Types not compatible: integer is not logical
  
  ── 2. Failure ('test_mapBarcodeToBarcode.R:21:3'): mapBarcodeToBarcode function 
  my_friend$mapBarcodeToBarcode(bc1, bc2)$idcs2 not equal to c(NA).
  Types not compatible: integer is not logical
  
  ══ DONE ════════════════════════════════════════════════════════════════════════
  Keep trying!
  Error: Test failures
  In addition: Warning message:
  package 'GenomeInfoDb' was built under R version 4.3.3 
  Execution halted
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in ‘inst/doc’ ... OK
* checking re-building of vignette outputs ... [35s/41s] OK
* checking PDF version of manual ... [44s/47s] WARNING
LaTeX errors when creating PDF version.
This typically indicates Rd problems.
LaTeX errors found:
! Font T1/ptm/m/n/10=ptmr8t at 10.0pt not loadable: Metric (TFM) file not found
.
<to be read again> 
                   relax 
l.8 \begin{document}
! Font T1/ptm/m/n/24.88=ptmr8t at 24.88pt not loadable: Metric (TFM) file not f
ound.
<to be read again> 
                   relax 
l.9 \chapter*{}
! Font T1/ptm/b/n/24.88=ptmb8t at 24.88pt not loadable: Metric (TFM) file not f
ound.
<to be read again> 
                   relax 
l.9 \chapter*{}
! Font T1/ptm/b/n/10=ptmb8t at 10.0pt not loadable: Metric (TFM) file not found
.
<to be read again> 
                   relax 
l.11 {\textbf{\huge Package `NetSciDataCompanion'}
! Font T1/ptm/b/n/20.74=ptmb8t at 20.74pt not loadable: Metric (TFM) file not f
ound.
<to be read again> 
                   relax 
l.11 {\textbf{\huge Package `NetSciDataCompanion'}
! Font T1/ptm/m/n/12=ptmr8t at 12.0pt not loadable: Metric (TFM) file not found
.
<to be read again> 
                   relax 
l.12 \par\bigskip{\large
! Font T1/ptm/m/n/14.4=ptmr8t at 14.4pt not loadable: Metric (TFM) file not fou
nd.
<to be read again> 
                   relax 
l.1 ...ine {subsection}{convertBetaToM}{2}{page.2}
! Font T1/ptm/b/n/14.4=ptmb8t at 14.4pt not loadable: Metric (TFM) file not fou
nd.
<to be read again> 
                   relax 
l.1 ...ine {subsection}{convertBetaToM}{2}{page.2}
! Font T1/phv/m/n/14.4=phvr8t at 14.4pt not loadable: Metric (TFM) file not fou
nd.
<to be read again> 
                   relax 
l.1 ...ine {subsection}{convertBetaToM}{2}{page.2}
! Font T1/ptm/m/it/10=ptmri8t at 10.0pt not loadable: Metric (TFM) file not fou
nd.
<to be read again> 
                   relax 
l.40 ... beta values to M-values.}{convertBetaToM}
! Font T1/ptm/m/sl/10=ptmro8t at 10.0pt not loadable: Metric (TFM) file not fou
nd.
<to be read again> 
                   relax 
l.107 ...ethylation_betas, tissue, array = "450k")
* checking PDF version of manual without index ... ERROR
* checking HTML version of manual ... NOTE
Found the following HTML validation problems:
CreateNetSciDataCompanionObject.html:4:1 (CreateNetSciDataCompanionObject.Rd:4): Warning: <link> inserting "type" attribute
CreateNetSciDataCompanionObject.html:12:1 (CreateNetSciDataCompanionObject.Rd:4): Warning: <script> proprietary attribute "onload"
CreateNetSciDataCompanionObject.html:12:1 (CreateNetSciDataCompanionObject.Rd:4): Warning: <script> inserting "type" attribute
CreateNetSciDataCompanionObject.html:17:1 (CreateNetSciDataCompanionObject.Rd:4): Warning: <table> lacks "summary" attribute
CreateNetSciDataCompanionObject.html:37:1 (CreateNetSciDataCompanionObject.Rd:15): Warning: <table> lacks "summary" attribute
NetSciDataCompanion.html:4:1 (NetSciDataCompanion.Rd:4): Warning: <link> inserting "type" attribute
NetSciDataCompanion.html:12:1 (NetSciDataCompanion.Rd:4): Warning: <script> proprietary attribute "onload"
NetSciDataCompanion.html:12:1 (NetSciDataCompanion.Rd:4): Warning: <script> inserting "type" attribute
NetSciDataCompanion.html:17:1 (NetSciDataCompanion.Rd:4): Warning: <table> lacks "summary" attribute
convertBetaToM.html:4:1 (convertBetaToM.Rd:4): Warning: <link> inserting "type" attribute
convertBetaToM.html:12:1 (convertBetaToM.Rd:4): Warning: <script> proprietary attribute "onload"
convertBetaToM.html:12:1 (convertBetaToM.Rd:4): Warning: <script> inserting "type" attribute
convertBetaToM.html:17:1 (convertBetaToM.Rd:4): Warning: <table> lacks "summary" attribute
convertBetaToM.html:35:1 (convertBetaToM.Rd:13): Warning: <table> lacks "summary" attribute
estimateCellCountsEpiSCORE.html:4:1 (estimateCellCountsEpiSCORE.Rd:4): Warning: <link> inserting "type" attribute
estimateCellCountsEpiSCORE.html:12:1 (estimateCellCountsEpiSCORE.Rd:4): Warning: <script> proprietary attribute "onload"
estimateCellCountsEpiSCORE.html:12:1 (estimateCellCountsEpiSCORE.Rd:4): Warning: <script> inserting "type" attribute
estimateCellCountsEpiSCORE.html:17:1 (estimateCellCountsEpiSCORE.Rd:4): Warning: <table> lacks "summary" attribute
estimateCellCountsEpiSCORE.html:35:1 (estimateCellCountsEpiSCORE.Rd:13): Warning: <table> lacks "summary" attribute
extractSampleAndGeneInfo.html:4:1 (extractSampleAndGeneInfo.Rd:4): Warning: <link> inserting "type" attribute
extractSampleAndGeneInfo.html:12:1 (extractSampleAndGeneInfo.Rd:4): Warning: <script> proprietary attribute "onload"
extractSampleAndGeneInfo.html:12:1 (extractSampleAndGeneInfo.Rd:4): Warning: <script> inserting "type" attribute
extractSampleAndGeneInfo.html:17:1 (extractSampleAndGeneInfo.Rd:4): Warning: <table> lacks "summary" attribute
extractSampleAndGeneInfo.html:31:1 (extractSampleAndGeneInfo.Rd:15): Warning: <table> lacks "summary" attribute
extractSampleAndGeneInfo.html:46:1 (extractSampleAndGeneInfo.Rd:26): Warning: <table> lacks "summary" attribute
filterBarcodesIntersection.html:4:1 (filterBarcodesIntersection.Rd:4): Warning: <link> inserting "type" attribute
filterBarcodesIntersection.html:12:1 (filterBarcodesIntersection.Rd:4): Warning: <script> proprietary attribute "onload"
filterBarcodesIntersection.html:12:1 (filterBarcodesIntersection.Rd:4): Warning: <script> inserting "type" attribute
filterBarcodesIntersection.html:17:1 (filterBarcodesIntersection.Rd:4): Warning: <table> lacks "summary" attribute
filterBarcodesIntersection.html:37:1 (filterBarcodesIntersection.Rd:15): Warning: <table> lacks "summary" attribute
filterBarcodesIntersection.html:57:1 (filterBarcodesIntersection.Rd:23): Warning: <table> lacks "summary" attribute
filterChromosome.html:4:1 (filterChromosome.Rd:4): Warning: <link> inserting "type" attribute
filterChromosome.html:12:1 (filterChromosome.Rd:4): Warning: <script> proprietary attribute "onload"
filterChromosome.html:12:1 (filterChromosome.Rd:4): Warning: <script> inserting "type" attribute
filterChromosome.html:17:1 (filterChromosome.Rd:4): Warning: <table> lacks "summary" attribute
filterChromosome.html:37:1 (filterChromosome.Rd:15): Warning: <table> lacks "summary" attribute
filterDuplicatesSeqDepth.html:4:1 (filterDuplicatesSeqDepth.Rd:4): Warning: <link> inserting "type" attribute
filterDuplicatesSeqDepth.html:12:1 (filterDuplicatesSeqDepth.Rd:4): Warning: <script> proprietary attribute "onload"
filterDuplicatesSeqDepth.html:12:1 (filterDuplicatesSeqDepth.Rd:4): Warning: <script> inserting "type" attribute
filterDuplicatesSeqDepth.html:17:1 (filterDuplicatesSeqDepth.Rd:4): Warning: <table> lacks "summary" attribute
filterDuplicatesSeqDepth.html:37:1 (filterDuplicatesSeqDepth.Rd:15): Warning: <table> lacks "summary" attribute
filterDuplicatesSeqDepthOther.html:4:1 (filterDuplicatesSeqDepthOther.Rd:4): Warning: <link> inserting "type" attribute
filterDuplicatesSeqDepthOther.html:12:1 (filterDuplicatesSeqDepthOther.Rd:4): Warning: <script> proprietary attribute "onload"
filterDuplicatesSeqDepthOther.html:12:1 (filterDuplicatesSeqDepthOther.Rd:4): Warning: <script> inserting "type" attribute
filterDuplicatesSeqDepthOther.html:17:1 (filterDuplicatesSeqDepthOther.Rd:4): Warning: <table> lacks "summary" attribute
filterDuplicatesSeqDepthOther.html:36:1 (filterDuplicatesSeqDepthOther.Rd:15): Warning: <table> lacks "summary" attribute
filterGenesByTPM.html:4:1 (filterGenesByTPM.Rd:4): Warning: <link> inserting "type" attribute
filterGenesByTPM.html:12:1 (filterGenesByTPM.Rd:4): Warning: <script> proprietary attribute "onload"
filterGenesByTPM.html:12:1 (filterGenesByTPM.Rd:4): Warning: <script> inserting "type" attribute
filterGenesByTPM.html:17:1 (filterGenesByTPM.Rd:4): Warning: <table> lacks "summary" attribute
filterGenesByTPM.html:37:1 (filterGenesByTPM.Rd:14): Warning: <table> lacks "summary" attribute
filterGenesProteins.html:4:1 (filterGenesProteins.Rd:4): Warning: <link> inserting "type" attribute
filterGenesProteins.html:12:1 (filterGenesProteins.Rd:4): Warning: <script> proprietary attribute "onload"
filterGenesProteins.html:12:1 (filterGenesProteins.Rd:4): Warning: <script> inserting "type" attribute
filterGenesProteins.html:17:1 (filterGenesProteins.Rd:4): Warning: <table> lacks "summary" attribute
filterGenesProteins.html:36:1 (filterGenesProteins.Rd:14): Warning: <table> lacks "summary" attribute
filterPurity.html:4:1 (filterPurity.Rd:4): Warning: <link> inserting "type" attribute
filterPurity.html:12:1 (filterPurity.Rd:4): Warning: <script> proprietary attribute "onload"
filterPurity.html:12:1 (filterPurity.Rd:4): Warning: <script> inserting "type" attribute
filterPurity.html:17:1 (filterPurity.Rd:4): Warning: <table> lacks "summary" attribute
filterPurity.html:37:1 (filterPurity.Rd:14): Warning: <table> lacks "summary" attribute
filterSampleType.html:4:1 (filterSampleType.Rd:4): Warning: <link> inserting "type" attribute
filterSampleType.html:12:1 (filterSampleType.Rd:4): Warning: <script> proprietary attribute "onload"
filterSampleType.html:12:1 (filterSampleType.Rd:4): Warning: <script> inserting "type" attribute
filterSampleType.html:17:1 (filterSampleType.Rd:4): Warning: <table> lacks "summary" attribute
filterSampleType.html:37:1 (filterSampleType.Rd:14): Warning: <table> lacks "summary" attribute
filterTumorType.html:4:1 (filterTumorType.Rd:4): Warning: <link> inserting "type" attribute
filterTumorType.html:12:1 (filterTumorType.Rd:4): Warning: <script> proprietary attribute "onload"
filterTumorType.html:12:1 (filterTumorType.Rd:4): Warning: <script> inserting "type" attribute
filterTumorType.html:17:1 (filterTumorType.Rd:4): Warning: <table> lacks "summary" attribute
filterTumorType.html:37:1 (filterTumorType.Rd:14): Warning: <table> lacks "summary" attribute
geneNameToENSG.html:4:1 (geneNameToENSG.Rd:4): Warning: <link> inserting "type" attribute
geneNameToENSG.html:12:1 (geneNameToENSG.Rd:4): Warning: <script> proprietary attribute "onload"
geneNameToENSG.html:12:1 (geneNameToENSG.Rd:4): Warning: <script> inserting "type" attribute
geneNameToENSG.html:17:1 (geneNameToENSG.Rd:4): Warning: <table> lacks "summary" attribute
geneNameToENSG.html:36:1 (geneNameToENSG.Rd:13): Warning: <table> lacks "summary" attribute
getGeneInfo.html:4:1 (getGeneInfo.Rd:4): Warning: <link> inserting "type" attribute
getGeneInfo.html:12:1 (getGeneInfo.Rd:4): Warning: <script> proprietary attribute "onload"
getGeneInfo.html:12:1 (getGeneInfo.Rd:4): Warning: <script> inserting "type" attribute
getGeneInfo.html:17:1 (getGeneInfo.Rd:4): Warning: <table> lacks "summary" attribute
getGeneInfo.html:37:1 (getGeneInfo.Rd:14): Warning: <table> lacks "summary" attribute
logCPMNormalization.html:4:1 (logCPMNormalization.Rd:4): Warning: <link> inserting "type" attribute
logCPMNormalization.html:12:1 (logCPMNormalization.Rd:4): Warning: <script> proprietary attribute "onload"
logCPMNormalization.html:12:1 (logCPMNormalization.Rd:4): Warning: <script> inserting "type" attribute
logCPMNormalization.html:17:1 (logCPMNormalization.Rd:4): Warning: <table> lacks "summary" attribute
logCPMNormalization.html:36:1 (logCPMNormalization.Rd:14): Warning: <table> lacks "summary" attribute
logCPMNormalization.html:46:1 (logCPMNormalization.Rd:21): Warning: <table> lacks "summary" attribute
logTPMNormalization.html:4:1 (logTPMNormalization.Rd:4): Warning: <link> inserting "type" attribute
logTPMNormalization.html:12:1 (logTPMNormalization.Rd:4): Warning: <script> proprietary attribute "onload"
logTPMNormalization.html:12:1 (logTPMNormalization.Rd:4): Warning: <script> inserting "type" attribute
logTPMNormalization.html:17:1 (logTPMNormalization.Rd:4): Warning: <table> lacks "summary" attribute
logTPMNormalization.html:38:1 (logTPMNormalization.Rd:16): Warning: <table> lacks "summary" attribute
logTPMNormalization.html:48:1 (logTPMNormalization.Rd:20): Warning: <table> lacks "summary" attribute
mapBarcodeToBarcode.html:4:1 (mapBarcodeToBarcode.Rd:4): Warning: <link> inserting "type" attribute
mapBarcodeToBarcode.html:12:1 (mapBarcodeToBarcode.Rd:4): Warning: <script> proprietary attribute "onload"
mapBarcodeToBarcode.html:12:1 (mapBarcodeToBarcode.Rd:4): Warning: <script> inserting "type" attribute
mapBarcodeToBarcode.html:17:1 (mapBarcodeToBarcode.Rd:4): Warning: <table> lacks "summary" attribute
mapBarcodeToBarcode.html:42:1 (mapBarcodeToBarcode.Rd:20): Warning: <table> lacks "summary" attribute
mapBarcodeToBarcode.html:56:1 (mapBarcodeToBarcode.Rd:28): Warning: <table> lacks "summary" attribute
mapProbesToGenes.html:4:1 (mapProbesToGenes.Rd:4): Warning: <link> inserting "type" attribute
mapProbesToGenes.html:12:1 (mapProbesToGenes.Rd:4): Warning: <script> proprietary attribute "onload"
mapProbesToGenes.html:12:1 (mapProbesToGenes.Rd:4): Warning: <script> inserting "type" attribute
mapProbesToGenes.html:17:1 (mapProbesToGenes.Rd:4): Warning: <table> lacks "summary" attribute
mapProbesToGenes.html:30:1 (mapProbesToGenes.Rd:13): Warning: <table> lacks "summary" attribute
probeToMeanPromoterMethylation.html:4:1 (probeToMeanPromoterMethylation.Rd:4): Warning: <link> inserting "type" attribute
probeToMeanPromoterMethylation.html:12:1 (probeToMeanPromoterMethylation.Rd:4): Warning: <script> proprietary attribute "onload"
probeToMeanPromoterMethylation.html:12:1 (probeToMeanPromoterMethylation.Rd:4): Warning: <script> inserting "type" attribute
probeToMeanPromoterMethylation.html:17:1 (probeToMeanPromoterMethylation.Rd:4): Warning: <table> lacks "summary" attribute
probeToMeanPromoterMethylation.html:33:1 (probeToMeanPromoterMethylation.Rd:9): Warning: <table> lacks "summary" attribute
* checking for non-standard things in the check directory ... NOTE
Found the following files/directories:
  ‘NetSciDataCompanion-manual.tex’
* checking for detritus in the temp directory ... OK
* DONE
Status: 2 ERRORs, 8 WARNINGs, 7 NOTEs

```